### PR TITLE
Allow Central Hub to collect Kolony Rewards

### DIFF
--- a/Part_Mods/Base_Parts.cfg
+++ b/Part_Mods/Base_Parts.cfg
@@ -15,3 +15,12 @@
         name = MKSModule
     }
 }
+
+@PART[KKAOSS_Central_Hub]:NEEDS[KolonyTools]
+{
+
+    MODULE
+    {
+        name = ModuleColonyRewards
+    }
+}


### PR DESCRIPTION
KPBS doesn't really have an equivalent to the Pioneer Module, so I figured the Central Hub was the best part allow to collect Kolony Rewards. I feel like the Central Hub gets all of the attention, but I really can't think of any better place for it. 

Also, in the notes at the top of this file, it says the hub and control station get to be power distributors, but they get the coupler module. I think the coupler is probably the better module, so should the notes change?